### PR TITLE
Add license and repository to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "name": "graphql-tag-pluck",
   "version": "0.2.2",
   "description": "Pluck graphql-tag template literals",
+  "license": "MIT",
+  "repository": "DAB0mB/graphql-tag-pluck",
   "main": "build/graphql-tag-pluck.js",
   "scripts": {
     "build": "webpack --config webpack_config.js",


### PR DESCRIPTION
This information isn't shown on the NPM page at the moment.

By adding this information to the package.json it's easier to find this reporitory when you're on the NPM page.