### PR TITLE
 Introduce registered modules - support Gatsby by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@
 Input:
 
 ```js
-import gql from 'graphql-tag'
+import gql from 'graphql-tag';
 
 const fragment = gql`
   fragment Foo on FooType {
     id
   }
-`
+`;
 
 const doc = gql`
   query foo {
@@ -23,7 +23,7 @@ const doc = gql`
   }
 
   ${fragment}
-`
+`;
 ```
 
 Output:
@@ -51,20 +51,23 @@ Originally created because of https://graphql-code-generator.com/.
 Once installed you can pluck GraphQL template literals using one of the following methods:
 
 ```js
-import gqlPluck, { gqlPluckFromFile, gqlPluckFromCodeString } from 'graphql-tag-pluck'
+import gqlPluck, {
+  gqlPluckFromFile,
+  gqlPluckFromCodeString,
+} from 'graphql-tag-pluck';
 
 // Returns promise
 gqlPluck.fromFile(filePath, {
-  useSync: true // Optional, will return string if so
-})
+  useSync: true, // Optional, will return string if so
+});
 
 // Returns string
-gqlPluck.fromFile.sync(filePath)
+gqlPluck.fromFile.sync(filePath);
 
 // Returns string
 gqlPluck.fromCodeString(codeString, {
-  fileExt: '.ts' // Optional, defaults to '.js'
-})
+  fileExt: '.ts', // Optional, defaults to '.js'
+});
 ```
 
 Template literals leaded by magic comments will also be extracted :-)
@@ -76,20 +79,62 @@ Template literals leaded by magic comments will also be extracted :-)
     media
     draftjs
   }
+`;
+```
+
+#### Transformation options may also be provided
+
+#### `gqlMagicComment`
+
+The magic comment anchor to look for when parsing GraphQL strings. Defaults to `graphql`, which may be translated into `/* GraphQL */` in code.
+
+#### `globalGqlIdentifierName`
+
+Allows to use a global identifier instead of one imported from a module.
+
+```js
+// `graphql` is a globally available function
+export const usersQuery = graphql`
+  {
+    users {
+      id
+      name
+    }
+  }
 `
 ```
 
-Transformation options may also be provided:
+#### `modules`
 
-- **`defaultGqlIdentifierName`** - The default GraphQL string parser identifier to look for. Defaults to `gql`, unless imported as something else from the `graphql-tag` package. This behavior can also be changed, see the `gqlPackName` option.
+An array of packages that are responsible for exporting the GraphQL string parser function. By default it supports `graphql-tag` and `gatsby`.
 
-- **`gqlMagicComment`** - The magic comment anchor to look for when parsing GraphQL strings. Defaults to `graphql`, which may be translated into `/* GraphQL */` in code.
+- **`name`** - The name of the package
 
-- **`gqlPackName`** - The name of the package that is responsible for exporting the GraphQL string parser function. Defaults to `graphql-tag`.
+- **`identifier`** - The GraphQL string parser identifier to look for. Uses default export if identifier is not defined.
+
+Default settings:
+
+```js
+{
+  modules: [
+    {
+      // uses a default export
+      // import gql from 'graphql-tag'
+      name: 'graphql-tag',
+    },
+    {
+      // uses named export
+      // import { graphql } from 'gatsby'
+      name: 'gatsby',
+      identifier: 'graphql',
+    },
+  ];
+}
+```
 
 I recommend you to look at the [source code](src/visitor.js) for a clearer understanding of the transformation options.
 
-supported file extensions are: `.js`, `.jsx`, `.ts`, `.tsx`, `.flow`, `.flow.js`, `.flow.jsx`,  `.graphqls`, `.graphql`, `.gqls`, `.gql`.
+supported file extensions are: `.js`, `.jsx`, `.ts`, `.tsx`, `.flow`, `.flow.js`, `.flow.jsx`, `.graphqls`, `.graphql`, `.gqls`, `.gql`.
 
 ### License
 

--- a/src/graphql-tag-pluck.test.js
+++ b/src/graphql-tag-pluck.test.js
@@ -835,4 +835,48 @@ describe('graphql-tag-pluck', () => {
       }
     `))
   })
+
+  it('should pluck graphql template literal from gatsby package', async () => {
+    const file = await tmp.file({
+      unsafeCleanup: true,
+      template: '/tmp/tmp-XXXXXX.js',
+    })
+
+    await fs.writeFile(file.name, freeText(`
+      import {graphql} from 'gatsby'
+
+      const fragment = graphql(\`
+        fragment Foo on FooType {
+          id
+        }
+      \`)
+
+      const doc = graphql\`
+        query foo {
+          foo {
+            ...Foo
+          }
+        }
+
+        \${fragment}
+      \`
+    `))
+
+    const gqlString = await gqlPluck.fromFile(file.name, {
+      defaultGqlIdentifierName: 'graphql',
+      gqlPackName: 'gatsby'
+    })
+
+    expect(gqlString).toEqual(freeText(`
+      fragment Foo on FooType {
+        id
+      }
+
+      query foo {
+        foo {
+          ...Foo
+        }
+      }
+    `))
+  })
 })

--- a/src/graphql-tag-pluck.test.js
+++ b/src/graphql-tag-pluck.test.js
@@ -724,7 +724,7 @@ describe('graphql-tag-pluck', () => {
     `))
   })
 
-  it('should be able to specify the default GraphQL identifier name', async () => {
+  it('should be able to specify the global GraphQL identifier name', async () => {
     const file = await tmp.file({
       unsafeCleanup: true,
       template: '/tmp/tmp-XXXXXX.js',
@@ -749,7 +749,7 @@ describe('graphql-tag-pluck', () => {
     `))
 
     const gqlString = await gqlPluck.fromFile(file.name, {
-      defaultGqlIdentifierName: 'graphql'
+      globalGqlIdentifierName: 'graphql'
     })
 
     expect(gqlString).toEqual(freeText(`
@@ -820,7 +820,9 @@ describe('graphql-tag-pluck', () => {
     `))
 
     const gqlString = await gqlPluck.fromFile(file.name, {
-      gqlPackName: 'my-graphql-tag'
+      modules: [{
+        name: 'my-graphql-tag'
+      }]
     })
 
     expect(gqlString).toEqual(freeText(`
@@ -862,10 +864,7 @@ describe('graphql-tag-pluck', () => {
       \`
     `))
 
-    const gqlString = await gqlPluck.fromFile(file.name, {
-      defaultGqlIdentifierName: 'graphql',
-      gqlPackName: 'gatsby'
-    })
+    const gqlString = await gqlPluck.fromFile(file.name)
 
     expect(gqlString).toEqual(freeText(`
       fragment Foo on FooType {

--- a/src/visitor.js
+++ b/src/visitor.js
@@ -2,36 +2,62 @@ import * as t from '@babel/types'
 import { freeText } from './utils'
 
 const defaults = {
-  defaultGqlIdentifierName: 'gql',
+  modules: [
+    {
+      name: 'graphql-tag'
+    },
+    {
+      name: 'gatsby',
+      identifier: 'graphql'
+    }
+  ],
   gqlMagicComment: 'graphql',
-  gqlPackName: 'graphql-tag',
 }
 
 export default (code, out, options = {}) => {
   // Apply defaults to options
-  let {
-    defaultGqlIdentifierName,
-    gqlMagicComment,
-    gqlPackName,
-  } = { ...defaults, ...options }
+  let {modules, globalGqlIdentifierName, gqlMagicComment} = {
+    ...defaults,
+    ...options
+  }
 
   // Prevent case related potential errors
-  defaultGqlIdentifierName = defaultGqlIdentifierName.toLowerCase()
   gqlMagicComment = gqlMagicComment.toLowerCase()
-  gqlPackName = gqlPackName.toLowerCase()
+  // normalize `name` and `identifier` values
+  modules = modules.map(mod => {
+    return {
+      name: mod.name.toLowerCase(),
+      identifier: mod.identifier && mod.identifier.toLowerCase()
+    }
+  });
+  globalGqlIdentifierName = globalGqlIdentifierName && globalGqlIdentifierName.toLowerCase()
+
+  // Keep imported identifiers
+  // import gql from 'graphql-tag' -> gql
+  // import { graphql } from 'gatsby' -> graphql
+  // Will result with ['gql', 'graphql']
+  const definedIdentifierNames = []
 
   // Will accumulate all template literals
   const gqlTemplateLiterals = []
-  // By default, we will look for `gql` calls
-  let gqlIdentifierName = defaultGqlIdentifierName
+
+  // Check if package is registered
+  function isValidPackage(name) {
+    return modules.some(pkg => pkg.name === name)
+  }
+
+  // Check if identifier is defined and imported from registered packages
+  function isValidIdentifier(name) {
+    return definedIdentifierNames.some(id => id === name) || (globalGqlIdentifierName && name === globalGqlIdentifierName)
+  }
 
   const pluckStringFromFile = ({ start, end }) => {
     return freeText(code
-      // Slice quotes
-      .slice(start + 1, end - 1)
-      // Erase string interpolations as we gonna export everything as a single
-      // string anyways
-      .replace(/\$\{[^}]*\}/g, '')
+        // Slice quotes
+        .slice(start + 1, end - 1)
+        // Erase string interpolations as we gonna export everything as a single
+        // string anyways
+        .replace(/\$\{[^}]*\}/g, '')
     )
   }
 
@@ -62,12 +88,12 @@ export default (code, out, options = {}) => {
         // e.g. import gql from 'graphql-tag' -> gql
         if (
           path.node.callee.name == 'require' &&
-          path.node.arguments[0].value == gqlPackName
+          isValidPackage(path.node.arguments[0].value)
         ) {
           if (!t.isVariableDeclarator(path.parent)) return
           if (!t.isIdentifier(path.parent.id)) return
 
-          gqlIdentifierName = path.parent.id.name
+          definedIdentifierNames.push(path.parent.id.name)
 
           return
         }
@@ -78,7 +104,7 @@ export default (code, out, options = {}) => {
         // e.g. gql(`query myQuery {}`) -> query myQuery {}
         if (
           t.isIdentifier(path.node.callee) &&
-          path.node.callee.name == gqlIdentifierName &&
+          isValidIdentifier(path.node.callee.name) &&
           t.isTemplateLiteral(arg0)
         ) {
           const gqlTemplateLiteral = pluckStringFromFile(arg0)
@@ -96,15 +122,37 @@ export default (code, out, options = {}) => {
       enter(path) {
         // Find the identifier name used from graphql-tag, es6
         // e.g. import gql from 'graphql-tag' -> gql
-        if (path.node.source.value != gqlPackName) return
+        if (!isValidPackage(path.node.source.value)) return
 
-        const gqlImportSpecifier = path.node.specifiers.find((importSpecifier) => {
-          return t.isImportDefaultSpecifier(importSpecifier)
-        })
+        const moduleNode = modules.find(
+          pkg => pkg.name === path.node.source.value,
+        )
+
+        const gqlImportSpecifier = path.node.specifiers.find(
+          importSpecifier => {
+            // When it's a default import and registered package has no named identifier
+            if (
+              t.isImportDefaultSpecifier(importSpecifier) &&
+              !moduleNode.identifier
+            ) {
+              return true
+            }
+
+            // When it's a named import that matches registered package's identifier
+            if (
+              t.isImportSpecifier(importSpecifier) &&
+              importSpecifier.imported.name === moduleNode.identifier
+            ) {
+              return true
+            }
+
+            return false
+          }
+        )
 
         if (!gqlImportSpecifier) return
 
-        gqlIdentifierName = gqlImportSpecifier.local.name
+        definedIdentifierNames.push(gqlImportSpecifier.local.name);
       },
     },
 
@@ -130,7 +178,7 @@ export default (code, out, options = {}) => {
         // e.g. gql `query myQuery {}` -> query myQuery {}
         if (
           !t.isIdentifier(path.node.tag) ||
-          path.node.tag.name != gqlIdentifierName
+          !isValidIdentifier(path.node.tag.name)
         ) {
           return
         }


### PR DESCRIPTION
More strict rules of which template literals are correct.


### Breaking changes

- `defaultGqlIdentifierName` renamed to `globalGqlIdentifierName` which I think makes more sense (we can even remove it)
- `gqlPackName` and `defaultGqlIdentifierName` are now `modules` (each module has a `name` property and an optional `identifier` - no identifier means it's a default export).