### PR TITLE
Move Typescript to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "@babel/parser": "^7.2.0",
     "@babel/traverse": "^7.1.6",
     "@babel/types": "^7.2.0",
-    "source-map-support": "^0.5.9",
-    "typescript": "^3.2.2"
+    "source-map-support": "^0.5.9"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",
@@ -36,6 +35,7 @@
     "babel-loader": "^8.0.0",
     "eslint": "^5.1.0",
     "eslint-loader": "^2.1.0",
+    "typescript": "^3.2.2",
     "jest": "^23.6.0",
     "webpack": "^4.16.1",
     "webpack-cli": "^3.1.0",


### PR DESCRIPTION
👋  Hello, I ran across a problem while upgrading to typescript 3.4 in our codebase.  

Since typescript is specified as a dependency here, it's installing version 3.3.3 of `tsc` in `node_modules/.bin/tsc`, which causes trouble when running `tsc` as a script with `yarn tsc`.

-Ian