### PR TITLE
Support trailing semicolons on expression statements

### DIFF
--- a/src/graphql-tag-pluck.test.js
+++ b/src/graphql-tag-pluck.test.js
@@ -508,32 +508,6 @@ describe('graphql-tag-pluck', () => {
     `))
   })
 
-  it('should pluck graphql-tag expression statements with a trailing semicolon leaded by a magic comment from .js file', async () => {
-    const file = await tmp.file({
-      unsafeCleanup: true,
-      template: '/tmp/tmp-XXXXXX.js',
-    })
-
-    await fs.writeFile(file.name, freeText(`
-      /* GraphQL */ \`
-        enum MessageTypes {
-          text
-          media
-          draftjs
-        }\`;
-    `))
-
-    const gqlString = await gqlPluck.fromFile(file.name)
-
-    expect(gqlString).toEqual(freeText(`
-      enum MessageTypes {
-        text
-        media
-        draftjs
-      }
-    `))
-  })
-
   it(`should NOT pluck other template literals from a .js file`, async () => {
     const file = await tmp.file({
       unsafeCleanup: true,
@@ -944,5 +918,10 @@ describe('graphql-tag-pluck', () => {
         }
       }
     `))
+  })
+
+  it('should pluck magic comment template literals with a trailing semicolon', async () => {
+    const gqlString = await gqlPluck.fromCodeString("/* GraphQL */ `{}`;")
+    expect(gqlString).toEqual("{}")
   })
 })

--- a/src/graphql-tag-pluck.test.js
+++ b/src/graphql-tag-pluck.test.js
@@ -508,6 +508,32 @@ describe('graphql-tag-pluck', () => {
     `))
   })
 
+  it('should pluck graphql-tag expression statements with a trailing semicolon leaded by a magic comment from .js file', async () => {
+    const file = await tmp.file({
+      unsafeCleanup: true,
+      template: '/tmp/tmp-XXXXXX.js',
+    })
+
+    await fs.writeFile(file.name, freeText(`
+      /* GraphQL */ \`
+        enum MessageTypes {
+          text
+          media
+          draftjs
+        }\`;
+    `))
+
+    const gqlString = await gqlPluck.fromFile(file.name)
+
+    expect(gqlString).toEqual(freeText(`
+      enum MessageTypes {
+        text
+        media
+        draftjs
+      }
+    `))
+  })
+
   it(`should NOT pluck other template literals from a .js file`, async () => {
     const file = await tmp.file({
       unsafeCleanup: true,


### PR DESCRIPTION
Fixes #27 by plucking from `path.node.expression` instead of `path.node`.