### PR TITLE
Ensure consistent module case checking

### DIFF
--- a/src/visitor.js
+++ b/src/visitor.js
@@ -77,7 +77,7 @@ export default (code, out, options = {}) => {
   // normalize `name` and `identifier` values
   modules = modules.map(mod => {
     return {
-      name: mod.name.toLowerCase(),
+      name: mod.name,
       identifier: mod.identifier && mod.identifier.toLowerCase(),
     }
   })
@@ -94,7 +94,7 @@ export default (code, out, options = {}) => {
 
   // Check if package is registered
   function isValidPackage(name) {
-    return modules.some(pkg => pkg.name === name)
+    return modules.some(pkg => pkg.name && name && pkg.name.toLowerCase() === name.toLowerCase())
   }
 
   // Check if identifier is defined and imported from registered packages
@@ -177,7 +177,7 @@ export default (code, out, options = {}) => {
         // e.g. import gql from 'graphql-tag' -> gql
         if (!isValidPackage(path.node.source.value)) return
 
-        const moduleNode = modules.find(pkg => pkg.name === path.node.source.value)
+        const moduleNode = modules.find(pkg => pkg.name.toLowerCase() === path.node.source.value.toLowerCase())
 
         const gqlImportSpecifier = path.node.specifiers.find(importSpecifier => {
           // When it's a default import and registered package has no named identifier


### PR DESCRIPTION
Fixes #50 

I took option 1 of my proposed fixes and just try to match the lower-cased module name with the lower-cased node source value. This way, if both the module name is capitalized _and_ the import, it'll correctly pick it up. This also shouldn't break people who were unwittingly relying on this behavior. 

It is kinda weird, but this would've saved me some time. I'm sure others have run into it as well. 

👍 	