### PR TITLE
Add graphql.macro to modules

### DIFF
--- a/src/visitor.js
+++ b/src/visitor.js
@@ -60,7 +60,11 @@ const defaults = {
     {
       name: 'apollo-server-cloudflare',
       identifier: 'gql',
-    }
+    },
+    {
+      name: 'graphql.macro',
+      identifier: 'gql',
+    },
   ],
   gqlMagicComment: 'graphql',
 }


### PR DESCRIPTION
Hi, 
This PR adds https://github.com/evenchange4/graphql.macro to the recognized module for parsing js documents.

Thanks.